### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/dist/schema.js
+++ b/dist/schema.js
@@ -60,7 +60,7 @@ class Schema {
         return dataName || 'no_data_name';
     }
     escapeSlashes(name) {
-        return name.replace(/\//g, '\\/');
+        return name.replace(/[\/\\]/g, '\\$&');
     }
     buildFormTable() {
         const table = new Table((0, util_1.format)('form_%s', this.form.row_id), null, { type: 'form', alias: this.alias(), form_id: this.form.id });

--- a/src/schema.js
+++ b/src/schema.js
@@ -70,7 +70,7 @@ export default class Schema {
   }
 
   escapeSlashes(name) {
-    return name.replace(/\//g, '\\/');
+    return name.replace(/\\/g, '\\\\').replace(/\//g, '\\/');
   }
 
   buildFormTable() {


### PR DESCRIPTION
Potential fixes for 2 code scanning alerts from the [Initial critical + high codeql](https://github.com/orgs/fulcrumapp/security/campaigns/4) security campaign:
- https://github.com/fulcrumapp/fulcrum-schema/security/code-scanning/2
To fix the problem, we need to modify the `escapeSlashes` function to also escape backslashes. This can be done by first replacing backslashes with double backslashes and then replacing slashes with escaped slashes. This ensures that both backslashes and slashes are properly escaped.
  


- https://github.com/fulcrumapp/fulcrum-schema/security/code-scanning/1
To fix the problem, we need to ensure that the `escapeSlashes` function also escapes backslashes in addition to slashes. This can be done by using a regular expression that matches both slashes and backslashes and replaces them with their escaped versions. We will use the `replace` method with a regular expression that includes both characters and the global flag to ensure all occurrences are replaced.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
